### PR TITLE
Add CSV output for descriptive statistics

### DIFF
--- a/descriptive_stats.py
+++ b/descriptive_stats.py
@@ -97,4 +97,7 @@ def categorize_amalgam(surfaces: float):
 
 if __name__ == "__main__":
     combined_df, summary_df = process_cycles()
+    # Save full combined dataset and summary statistics to CSV files
+    combined_df.to_csv("combined_dataset.csv", index=False)
+    summary_df.to_csv("summary_statistics.csv", index=False)
     print(summary_df.head())


### PR DESCRIPTION
## Summary
- modify `descriptive_stats.py` so that it saves the combined dataset and summary statistics to CSV when run as a script

## Testing
- `python -m py_compile descriptive_stats.py analysis.py download.py`

------
https://chatgpt.com/codex/tasks/task_e_68844863679883239263decc7ba1c1b6