### PR TITLE
Add requirements file and install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ The scripts rely on the following Python packages:
 - `requests`
 - `statsmodels` (for survey-weighted ANOVA)
 
-Install the dependencies with `pip`:
+All required packages are listed in `requirements.txt`. Install them with:
 
 ```bash
-pip install pandas numpy scipy matplotlib pyreadstat requests statsmodels
+pip install -r requirements.txt
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pandas
+numpy
+scipy
+matplotlib
+pyreadstat
+requests
+statsmodels

--- a/run_workflow.sh
+++ b/run_workflow.sh
@@ -2,6 +2,9 @@
 # Run the full NHANES inflammation analysis workflow
 set -euo pipefail
 
+# Step 0: Install Python dependencies
+python3 -m pip install -r requirements.txt
+
 # Step 1: Download data
 python3 download.py
 


### PR DESCRIPTION
## Summary
- provide `requirements.txt` for Python dependencies
- update setup instructions in `README` to use the requirements file
- install requirements as step 0 in `run_workflow.sh`

## Testing
- `python3 -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688826a39a508323aae19c53f060c20e