### PR TITLE
Add CRP and mercury t-test analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # NHANES Inflammation Analysis
 
-This repository contains Python scripts and a Jupyter notebook used to download and analyze data from the National Health and Nutrition Examination Survey (NHANES). The analysis focuses on inflammation markers such as Neutrophil-to-Lymphocyte Ratio (NLR), Monocyte-to-Lymphocyte Ratio (MLR), Platelet-to-Lymphocyte Ratio (PLR) and the Systemic Immune-Inflammation Index (SII) in relation to dental amalgam surfaces.
+This repository contains Python scripts and a Jupyter notebook used to download and analyze data from the National Health and Nutrition Examination Survey (NHANES). The analysis focuses on inflammation markers such as Neutrophil-to-Lymphocyte Ratio (NLR), Monocyte-to-Lymphocyte Ratio (MLR), Platelet-to-Lymphocyte Ratio (PLR), the Systemic Immune-Inflammation Index (SII), C‑Reactive Protein (CRP) and blood mercury levels in relation to dental amalgam surfaces.
 
 ## Repository contents
 
 - `download.py` – downloads the required NHANES XPT files for each cycle.
-- `descriptive_stats.py` – merges demographic, dental and complete blood count files, computes summary statistics for inflammation markers and exports CSV files.
-- `analysis.py` – prepares analysis groups and performs t‑tests (and optional survey‑weighted ANOVA via R).
+- `descriptive_stats.py` – merges demographic, dental and complete blood count files, computes summary statistics for inflammation markers (including CRP and blood mercury) and exports CSV files.
+- `analysis.py` – prepares analysis groups and performs t‑tests (including CRP and blood mercury) and optional survey‑weighted ANOVA via R.
 - `NHANES_HG_OPT.ipynb` – original notebook that demonstrates the workflow.
 - `run_workflow.sh` – runs the entire workflow in one command.
 
@@ -54,7 +54,7 @@ To run every step in sequence, execute:
    ```bash
    python analysis.py
    ```
-   T‑test results are written to `ttest_results.csv`.
+   T‑test results—including CRP and blood mercury comparisons—are written to `ttest_results.csv`.
 
 4. **Generate box plots**
 

--- a/analysis.py
+++ b/analysis.py
@@ -31,7 +31,7 @@ def prepare_groups(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def run_t_tests(df: pd.DataFrame) -> pd.DataFrame:
-    markers = ["NLR", "MLR", "PLR", "SII"]
+    markers = ["NLR", "MLR", "PLR", "SII", "CRP", "BloodMercury"]
     comparisons = [("None", "Low"), ("None", "Medium"), ("None", "High")]
     strata_vars = ["Gender", "Race", "AgeGroup"]
 
@@ -68,7 +68,7 @@ def run_t_tests(df: pd.DataFrame) -> pd.DataFrame:
 def survey_weighted_anova(df: pd.DataFrame) -> pd.DataFrame:
     """Approximate survey-weighted ANOVA using statsmodels."""
 
-    markers = ["NLR", "MLR", "PLR", "SII"]
+    markers = ["NLR", "MLR", "PLR", "SII", "CRP", "BloodMercury"]
     df = df.rename(columns={"Amalgam Group": "Amalgam_Group"})
 
     results = []


### PR DESCRIPTION
## Summary
- include CRP and BloodMercury in `run_t_tests`
- also allow survey-weighted ANOVA on these markers
- document new markers in README and note they are in the t-test output

## Testing
- `python -m py_compile analysis.py descriptive_stats.py box_plots.py download.py`

------
https://chatgpt.com/codex/tasks/task_e_688c2000f974832380453fa0a5d2a271