### PR TITLE
Separate regression models from main analysis script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This repository provides Python scripts to download and analyze data from the Na
 
 - `download.py` – downloads the required NHANES XPT files for each cycle (1999–2018).
 - `descriptive_stats.py` – merges demographic, dental, complete blood count, CRP and mercury files, computes inflammation markers and exports `combined_dataset.csv`, `summary_statistics.csv` and `demographic_statistics.csv`.
-- `analysis.py` – prepares analysis groups and performs t‑tests (including CRP and blood mercury) with an optional survey‑weighted ANOVA using `statsmodels`; results are saved to `ttest_results.csv`.
+- `analysis.py` – prepares analysis groups and performs t‑tests (including CRP and blood mercury), saving results to `ttest_results.csv`.
+- `regression_models.py` – fits cubic spline and logistic regression models for each marker and exports coefficient and p‑value tables to CSV files.
 - `box_plots.py` – reads `ttest_results.csv` and generates box plots for significant comparisons, saving figures to the `output` directory.
 - `run_workflow.sh` – runs the entire workflow in one command.
 
@@ -50,14 +51,21 @@ To run every step in sequence, execute:
    ```
    Produces `combined_dataset.csv`, `summary_statistics.csv` and `demographic_statistics.csv`.
 
-3. **Run analyses**
+3. **Run t-test analyses**
 
    ```bash
    python analysis.py
    ```
    Writes t‑test results to `ttest_results.csv`.
 
-4. **Generate box plots**
+4. **Run regression models**
+
+   ```bash
+   python regression_models.py
+   ```
+   Produces cubic spline and logistic regression outputs: `cubic_spline_coeffs.csv`, `cubic_spline_pvalues.csv`, `logistic_coeffs.csv` and `logistic_pvalues.csv`.
+
+5. **Generate box plots**
 
    ```bash
    python box_plots.py

--- a/run_workflow.sh
+++ b/run_workflow.sh
@@ -11,8 +11,11 @@ python3 download.py
 # Step 2: Generate descriptive statistics
 python3 descriptive_stats.py
 
-# Step 3: Run analyses
+# Step 3: Run t-test analyses
 python3 analysis.py
 
-# Step 4: Generate box plots
+# Step 4: Run regression models
+python3 regression_models.py
+
+# Step 5: Generate box plots
 python3 box_plots.py


### PR DESCRIPTION
## Summary
- remove regression-related ANOVA code from `analysis.py` leaving t-test workflow only
- call new `regression_models.py` in `run_workflow.sh` to run cubic spline and logistic regressions separately
- document the regression step in the README

## Testing
- `python -m py_compile analysis.py regression_models.py`
- `bash -n run_workflow.sh`


------
https://chatgpt.com/codex/tasks/task_e_68928c09f6a483238e1d9e28dee31d20