### PR TITLE
Skip cycles without NHANES dental data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NHANES Inflammation Analysis
 
 This repository provides Python scripts to download and analyze data from the National Health and Nutrition Examination Survey (NHANES). The analysis focuses on inflammation markers such as Neutrophil-to-Lymphocyte Ratio (NLR), Monocyte-to-Lymphocyte Ratio (MLR), Platelet-to-Lymphocyte Ratio (PLR), the Systemic Immune-Inflammation Index (SII), C‑Reactive Protein (CRP) and blood mercury levels in relation to dental amalgam surfaces.
+NHANES did not collect dental examination data during the 2005–2006 and 2007–2008 cycles, so these years are skipped in the workflow.
 
 ## Repository contents
 

--- a/descriptive_stats.py
+++ b/descriptive_stats.py
@@ -8,8 +8,7 @@ CBC_DEMO_DENTAL_FILES = {
     "1999-2000": ("L40_0.xpt", "DEMO.xpt", "OHXDENT.xpt", "LAB11.xpt", "LAB06HM.xpt"),
     "2001-2002": ("L25_B.xpt", "DEMO_B.xpt", "OHXDEN_B.xpt", "L11_B.xpt", "L06_2_B.xpt"),
     "2003-2004": ("L25_C.xpt", "DEMO_C.xpt", "OHXDEN_C.xpt", "L11_C.xpt", "L06BMT_C.xpt"),
-    "2005-2006": ("CBC_D.xpt", "DEMO_D.xpt", "OHXDEN_D.xpt", "CRP_D.xpt", "PbCd_D.xpt"),
-    "2007-2008": ("CBC_E.xpt", "DEMO_E.xpt", "OHXDEN_E.xpt", "CRP_E.xpt", "PbCd_E.xpt"),
+    # Dental exams were not conducted in 2005-2006 and 2007-2008
     "2009-2010": ("CBC_F.xpt", "DEMO_F.xpt", "OHXDEN_F.xpt", "CRP_F.xpt", "PbCd_F.xpt"),
     "2011-2012": ("CBC_G.xpt", "DEMO_G.xpt", "OHXDEN_G.xpt", "CRP_G.xpt", "PbCd_G.xpt"),
     "2013-2014": ("CBC_H.xpt", "DEMO_H.xpt", "OHXDEN_H.xpt", "CRP_H.xpt", "PBCD_H.xpt"),

--- a/download.py
+++ b/download.py
@@ -44,7 +44,8 @@ FILE_SUFFIXES = {
     },
     "2005-2006": {
         "Demographics": "DEMO_D.xpt",
-        "Dental": "OHXDEN_D.xpt",
+        # No dental examination data released for this cycle
+        "Dental": None,
         "CRP": "CRP_D.xpt",
         "Mercury": "PbCd_D.xpt",
         "BMI": "BMX_D.xpt",
@@ -53,7 +54,8 @@ FILE_SUFFIXES = {
     },
     "2007-2008": {
         "Demographics": "DEMO_E.xpt",
-        "Dental": "OHXDEN_E.xpt",
+        # No dental examination data released for this cycle
+        "Dental": None,
         "CRP": "CRP_E.xpt",
         "Mercury": "PbCd_E.xpt",
         "BMI": "BMX_E.xpt",
@@ -132,6 +134,9 @@ def download_all(data_dir="nhanes_data"):
         print(f"\nDownloading files for {cycle}")
         base_url = BASE_URLS[cycle]
         for label, filename in FILE_SUFFIXES[cycle].items():
+            if not filename:
+                print(f"Skipping {label}: no file for this cycle")
+                continue
             url = base_url + filename
             save_path = os.path.join(data_dir, filename)
             try:


### PR DESCRIPTION
## Summary
- skip NHANES cycles 2005-2006 and 2007-2008 where no dental exam data exist
- handle missing dental files gracefully when downloading
- document unavailable dental cycles in the README

## Testing
- `python -m py_compile download.py descriptive_stats.py`
- `python - <<'PY'
import download
for cycle in ['2005-2006','2007-2008']:
    print('Cycle',cycle)
    base_url = download.BASE_URLS[cycle]
    for label, filename in download.FILE_SUFFIXES[cycle].items():
        if not filename:
            print(' ', label, '-> skipped')
        else:
            print(' ', label, '->', base_url + filename)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6893752428e883238e6c8aeb30a176e8