### PR TITLE
Log downloads and analyze only complete NHANES cycles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ combined_dataset.csv
 summary_statistics.csv
 output/
 ttest_results.csv
+download_log.csv
+demographic_statistics.csv
+cubic_spline_coeffs.csv
+cubic_spline_pvalues.csv
+logistic_coeffs.csv
+logistic_pvalues.csv

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 This repository provides Python scripts to download and analyze data from the National Health and Nutrition Examination Survey (NHANES). The analysis focuses on inflammation markers such as Neutrophil-to-Lymphocyte Ratio (NLR), Monocyte-to-Lymphocyte Ratio (MLR), Platelet-to-Lymphocyte Ratio (PLR), the Systemic Immune-Inflammation Index (SII), C‑Reactive Protein (CRP) and blood mercury levels in relation to dental amalgam surfaces.
 NHANES did not collect dental examination data during the 2005–2006 and 2007–2008 cycles, so these years are skipped in the workflow.
+Download outcomes are tracked in `download_log.csv`, and subsequent analyses use only cycles where every required file was retrieved successfully.
 
 ## Repository contents
 
-- `download.py` – downloads the required NHANES XPT files for each cycle (1999–2018).
+- `download.py` – downloads the required NHANES XPT files for each cycle (1999–2018) and records the outcome of each download in `download_log.csv`.
 - `descriptive_stats.py` – merges demographic, dental, complete blood count, CRP and mercury files, computes inflammation markers and exports `combined_dataset.csv`, `summary_statistics.csv` and `demographic_statistics.csv`.
 - `analysis.py` – prepares analysis groups and performs t‑tests (including CRP and blood mercury), saving results to `ttest_results.csv`.
 - `regression_models.py` – fits cubic spline and logistic regression models for each marker and exports coefficient and p‑value tables to CSV files.
-- `box_plots.py` – reads `ttest_results.csv` and generates box plots for significant comparisons, saving figures to the `output` directory.
 - `run_workflow.sh` – runs the entire workflow in one command.
 
 ## Setup
@@ -43,7 +43,7 @@ To run every step in sequence, execute:
    ```bash
    python download.py
    ```
-   Data files are saved into a directory named `nhanes_data`.
+   Data files are saved into a directory named `nhanes_data`, and `download_log.csv` notes which files succeeded or failed.
 
 2. **Generate descriptive statistics**
 
@@ -65,13 +65,6 @@ To run every step in sequence, execute:
    python regression_models.py
    ```
    Produces cubic spline and logistic regression outputs: `cubic_spline_coeffs.csv`, `cubic_spline_pvalues.csv`, `logistic_coeffs.csv` and `logistic_pvalues.csv`.
-
-5. **Generate box plots**
-
-   ```bash
-   python box_plots.py
-   ```
-   Reads `ttest_results.csv` and saves figures for significant comparisons to the `output` directory.
 
 ## License
 

--- a/run_workflow.bat
+++ b/run_workflow.bat
@@ -16,9 +16,6 @@ python analysis.py || goto :error
 REM Step 4: Run regression models
 python regression_models.py || goto :error
 
-REM Step 5: Generate box plots
-python box_plots.py || goto :error
-
 echo Workflow completed successfully.
 exit /B 0
 

--- a/run_workflow.sh
+++ b/run_workflow.sh
@@ -16,6 +16,3 @@ python3 analysis.py
 
 # Step 4: Run regression models
 python3 regression_models.py
-
-# Step 5: Generate box plots
-python3 box_plots.py


### PR DESCRIPTION
## Summary
- Record success or failure of each NHANES file download in `download_log.csv`
- Use download log to restrict statistical analysis to cycles with all required files
- Remove box plot generation from workflow and documentation

## Testing
- `python -m py_compile download.py descriptive_stats.py analysis.py regression_models.py`
- `python download.py`
- `python descriptive_stats.py`
- `python analysis.py`
- `python regression_models.py` *(fails: Pandas data cast to numpy dtype of object)*

------
https://chatgpt.com/codex/tasks/task_e_68937fd02354832387889ff112d0dbd7