### PR TITLE
Fix regression model numeric conversion

### DIFF
--- a/regression_models.py
+++ b/regression_models.py
@@ -24,50 +24,56 @@ def _encode_covariates(df: pd.DataFrame) -> pd.DataFrame:
     -------
     DataFrame with numeric covariates and dummy variables ready for modeling.
     """
-    covars = df[
-        [
-            "amalgam_surfaces",
-            "RIDAGEYR",
-            "RIAGENDR",
-            "RIDRETH1",
-        ]
-    ].copy()
+    covars = (
+        df[["amalgam_surfaces", "RIDAGEYR", "RIAGENDR", "RIDRETH1"]]
+        .apply(pd.to_numeric, errors="coerce")
+        .copy()
+    )
     # Sex: 1=male, 2=female -> female indicator
     covars["female"] = (covars.pop("RIAGENDR") == 2).astype(int)
-    race_dummies = pd.get_dummies(covars.pop("RIDRETH1"), prefix="race", drop_first=True)
+    race_dummies = pd.get_dummies(
+        covars.pop("RIDRETH1").astype(int), prefix="race", drop_first=True
+    )
     covars = pd.concat([covars, race_dummies], axis=1)
-    return covars
+    return covars.apply(pd.to_numeric, errors="coerce")
 
 
-def fit_cubic_spline(df: pd.DataFrame, marker: str) -> sm.regression.linear_model.RegressionResultsWrapper:
+def fit_cubic_spline(
+    df: pd.DataFrame, marker: str
+) -> sm.regression.linear_model.RegressionResultsWrapper:
     """Fit OLS with a cubic spline for time."""
-    data = df[["time", marker, "amalgam_surfaces", "RIDAGEYR", "RIAGENDR", "RIDRETH1"]].dropna()
-    y = data[marker]
+    cols = ["time", marker, "amalgam_surfaces", "RIDAGEYR", "RIAGENDR", "RIDRETH1"]
+    data = df[cols].apply(pd.to_numeric, errors="coerce").dropna()
+    y = data[marker].astype(float)
     covars = _encode_covariates(data)
     time_spline = dmatrix(
         "bs(time, degree=3, df=4, include_intercept=False)",
         {"time": data["time"]},
         return_type="dataframe",
     )
-    X = pd.concat([time_spline, covars], axis=1)
+    X = pd.concat([time_spline, covars], axis=1).astype(float)
     X = sm.add_constant(X)
     model = sm.OLS(y, X).fit()
     return model
 
 
-def fit_logistic(df: pd.DataFrame, marker: str) -> sm.discrete.discrete_model.BinaryResultsWrapper | None:
+
+def fit_logistic(
+    df: pd.DataFrame, marker: str
+) -> sm.discrete.discrete_model.BinaryResultsWrapper | None:
     """Fit logistic regression with marker dichotomized at its median.
 
     Returns ``None`` if the model fails to converge.
     """
-    data = df[["time", marker, "amalgam_surfaces", "RIDAGEYR", "RIAGENDR", "RIDRETH1"]].dropna()
+    cols = ["time", marker, "amalgam_surfaces", "RIDAGEYR", "RIAGENDR", "RIDRETH1"]
+    data = df[cols].apply(pd.to_numeric, errors="coerce").dropna()
     if data.empty:
         return None
     median = data[marker].median()
     data["binary"] = (data[marker] > median).astype(int)
     covars = _encode_covariates(data)
     covars["time"] = data["time"]
-    X = sm.add_constant(covars)
+    X = sm.add_constant(covars.astype(float))
     try:
         model = sm.Logit(data["binary"], X).fit(disp=False)
     except Exception as exc:  # pragma: no cover - handle convergence issues
@@ -80,7 +86,7 @@ def run_models() -> None:
     """Run regression models for each marker and save results to CSV files."""
     df, _ = process_cycles()
     # Approximate a time variable from the survey cycle start year
-    df["time"] = df["Cycle"].str.slice(0, 4).astype(int)
+    df = df.assign(time=df["Cycle"].str.slice(0, 4).astype(int)).copy()
 
     cubic_coeffs: dict[str, pd.Series] = {}
     cubic_pvals: dict[str, pd.Series] = {}


### PR DESCRIPTION
## Summary
- ensure regression covariates are numeric and generate race dummies safely
- cast design matrices to float for cubic spline and logistic models
- defragment combined dataset when creating time column

## Testing
- `bash run_workflow.sh`

------
https://chatgpt.com/codex/tasks/task_e_68941958ce4c83238b9f961de2aa7f5d